### PR TITLE
Use migrations to mark default workspace as active if no other active workspace is set.

### DIFF
--- a/pkg/state/backend.go
+++ b/pkg/state/backend.go
@@ -22,7 +22,7 @@ var ErrNilBucket = errors.New("state: No bucket found")
 // deal with ProtoBuf messages.
 type Backend interface {
 	// -- Buckets
-	// CreateBucketIfNotExists attempts to create a bucket with a given name, if it doens't exist.
+	// CreateBucketIfNotExists attempts to create a bucket with a given name, if it doesn't exist.
 	CreateBucketIfNotExists(name string) error
 	// HasBucket returns true if this Backend has a bucket with the given name.
 	HasBucket(name string) bool

--- a/pkg/state/bolt/bolt_backend.go
+++ b/pkg/state/bolt/bolt_backend.go
@@ -58,6 +58,11 @@ func (b *boltBackend) Read(bucket string, key string) ([]byte, error) {
 
 	err := b.db.View(func(tx *boltdb.Tx) error {
 		bucket := tx.Bucket([]byte(bucket))
+
+		if bucket == nil {
+			return state.ErrNilBucket
+		}
+
 		value = bucket.Get([]byte(key))
 
 		return nil

--- a/pkg/state/migrate/versions/1496518709.go
+++ b/pkg/state/migrate/versions/1496518709.go
@@ -1,0 +1,45 @@
+package versions
+
+import (
+	"github.com/SeerUK/tid/pkg/state"
+	"github.com/SeerUK/tid/pkg/state/migrate"
+	"github.com/SeerUK/tid/pkg/types"
+	"github.com/SeerUK/tid/pkg/util"
+)
+
+func init() {
+	migrate.RegisterMigration(&Migration1496518709{})
+}
+
+// Migration1496518709 is a backend migration created at 1496518709 unix time.
+type Migration1496518709 struct{}
+
+// Description provides a description of what the migration is doing.
+func (m *Migration1496518709) Description() string {
+	return "Set up status to point to the default workspace if no workspace is set."
+}
+
+// Migrate performs the migration.
+func (m *Migration1496518709) Migrate(backend state.Backend) error {
+	factory := util.NewStandardFactory(backend)
+	sysGateway := factory.BuildSysGateway()
+
+	status, err := sysGateway.FindOrCreateStatus()
+
+	if err != nil {
+		return err
+	}
+
+	if status.Workspace != "" {
+		return nil
+	}
+
+	status.Workspace = types.TrackingStatusDefaultWorkspace
+
+	return sysGateway.PersistStatus(status)
+}
+
+// Version returns the version number of the migration.
+func (m *Migration1496518709) Version() uint {
+	return 1496518709
+}


### PR DESCRIPTION
Fixes #13. 

I've also added in a fix to prevent the nil pointer panic that was caused if a bucket was nil. 